### PR TITLE
Add cancelling orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The server should be visible on your local machine at `http://0.0.0.0:5000`
 - `POST /orders/<int:order_id>/items` - adds an item to the order with id of `order_id` and return the added item or `404` if the order doesn't exist
 - `DELETE /orders/<int:order_id>` - deletes the order with id of `order_id` if it exists and returns a `204` regardless of whether an actually deletion was performed
 - `DELETE /orders/<int:order_id>/items/<int:item_id>` - deletes the item with id of `item_id` in the order with id of `order_id`. It returns a `404` if either the order or the item doesn't exist.
+- `POST /orders/<int:order_id>/cancel` - cancels the order with id of `order_id`. Returns `200` for successful cancelling, returns `404` for orders not exist, returns `400` if the order in status `Completed/Returned`.
 
 
 ## Testing

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -46,7 +46,7 @@ if __name__ != "__main__":
     app.logger.info("Logging handler established")
 
 app.logger.info(70 * "*")
-app.logger.info("  P E T   S T O R E   S E R V I C E  ".center(70, "*"))
+app.logger.info("  O R D E R S   S E R V I C E  ".center(70, "*"))
 app.logger.info(70 * "*")
 
 try:
@@ -56,4 +56,4 @@ except Exception as error:
     # gunicorn requires exit code 4 to stop spawning workers when they die
     sys.exit(4)
 
-app.logger.info("Service inititalized!")
+app.logger.info("Service initialized!")

--- a/service/error_handlers.py
+++ b/service/error_handlers.py
@@ -29,7 +29,7 @@ def request_validation_error(error):
 
 @app.errorhandler(status.HTTP_400_BAD_REQUEST)
 def bad_request(error):
-    """Handles bad reuests with 400_BAD_REQUEST"""
+    """Handles bad requests with 400_BAD_REQUEST"""
     message = str(error)
     app.logger.warning(message)
     return (

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -17,11 +17,11 @@ Test Factory to make fake objects for testing
 """
 import factory
 from factory.fuzzy import FuzzyChoice
-from service.models import CustomerOrder
+from service.models import CustomerOrder, Item, Status
 
 
 class CustomerOrderFactory(factory.Factory):
-    """Creates fake pets that you don't have to feed"""
+    """Generate fake CustomerOrder objects"""
 
     class Meta:
         model = CustomerOrder
@@ -29,8 +29,10 @@ class CustomerOrderFactory(factory.Factory):
     id = factory.Sequence(lambda n: n)
     customer_id = factory.Sequence(lambda n: n)
     address = factory.Faker("address")
-    # address_line2 = factory.Faker("address")
-    # city = factory.Faker("city")
-    # state = factory.Faker("state")
-    # zip_code = factory.Faker("zipcode")
-    # status = FuzzyChoice(choices=["pending", "completed", "canceled"])
+    status = FuzzyChoice(choices=[Status.Received, Status.Processing,
+                         Status.Completed, Status.Cancelled, Status.Returned])
+
+
+class ItemFactory(factory.Factory):
+    """Generate fake items"""
+    pass


### PR DESCRIPTION
In this PR:
- Added `status` attribute to `CustomerOrder`
- Updated `CustomerOrderFactory` to generate random `status`
- Added route to cancel an order: `POST /orders/{id}/cancel`
- Added test cases for cancelling orders

Coverage:
```
Name                        Stmts   Miss  Cover   Missing
---------------------------------------------------------
service/__init__.py            27      4    85%   45, 54-57
service/error_handlers.py      32      3    91%   87-89
service/models.py             119      1    99%   186
service/routes.py             110      0   100%
service/status.py              46      0   100%
---------------------------------------------------------
TOTAL                         334      8    98%
----------------------------------------------------------------------
Ran 31 tests in 4.367s
```