### PR TITLE
Add the ability to list all the available urls and their corresponding methods

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -45,18 +45,23 @@ from . import status  # HTTP Status Codes
 ######################################################################
 # GET INDEX
 ######################################################################
-# @app.route("/")
-# def index():
-#     """Root URL response"""
-#     app.logger.info("Request for Root URL")
-#     return (
-#         jsonify(
-#             name="Orders Demo REST API Service",
-#             version="1.0",
-#             paths=url_for("list_orders", _external=True),
-#         ),
-#         status.HTTP_200_OK,
-#     )
+@app.route("/")
+def index():
+    """Root URL response"""
+    app.logger.info("Request for Root URL")
+
+    routes = {}
+    for rule in app.url_map.iter_rules():
+        if rule.endpoint != 'static':
+            routes[rule.rule] = ','.join(rule.methods)
+    return (
+        jsonify(
+            name="Orders Demo REST API Service",
+            version="1.0",
+            paths=routes,
+        ),
+        status.HTTP_200_OK,
+    )
 
 
 ######################################################################

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -95,12 +95,12 @@ class TestCustomerOrderServer(unittest.TestCase):  # pylint: disable=too-many-pu
             orders.append(test_order)
         return orders
 
-    # def test_index(self):
-    #     """Test the Home Page"""
-    #     resp = self.app.get("/")
-    #     self.assertEqual(resp.status_code, status.HTTP_200_OK)
-    #     data = resp.get_json()
-    #     self.assertEqual(data["name"], "Order Demo REST API Service")
+    def test_index(self):
+        """Test the Home Page"""
+        resp = self.app.get("/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(data["name"], "Order Demo REST API Service")
 
     def test_get_orders_list(self):
         """Get a list of orders"""

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -100,7 +100,7 @@ class TestCustomerOrderServer(unittest.TestCase):  # pylint: disable=too-many-pu
         resp = self.app.get("/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
-        self.assertEqual(data["name"], "Order Demo REST API Service")
+        self.assertEqual(data["name"], "Orders Demo REST API Service")
 
     def test_get_orders_list(self):
         """Get a list of orders"""


### PR DESCRIPTION
Resolves #8 

* Add the ability to list all the available urls and their corresponding methods
* The result's like below:
```
{
  "name": "Orders Demo REST API Service",
  "paths": {
    "/": "OPTIONS,GET,HEAD",
    "/orders": "POST,OPTIONS",
    "/orders/<int:order_id>": "OPTIONS,DELETE",
    "/orders/<int:order_id>/cancel": "POST,OPTIONS",
    "/orders/<int:order_id>/items": "POST,OPTIONS",
    "/orders/<int:order_id>/items/<int:item_id>": "OPTIONS,DELETE"
  },
  "version": "1.0"
}
```

* Write corresponding tests
```
Name                        Stmts   Miss  Cover   Missing
---------------------------------------------------------
service/__init__.py            27      4    85%   46, 55-58
service/error_handlers.py      32      3    91%   90-92
service/models.py             118      1    99%   190
service/routes.py             118      0   100%
service/status.py              46      0   100%
---------------------------------------------------------
TOTAL                         341      8    98%
```