### PR TITLE
added items to sample data

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -26,7 +26,7 @@ def before_all(context):
     # -- SET LOG LEVEL: behave --logging-level=ERROR ...
     # on behave command-line or in "behave.ini"
     context.config.setup_logging()
-
+    context.order_ids = list()
 
 def after_all(context):
     """ Executed after all tests """

--- a/features/orders.feature
+++ b/features/orders.feature
@@ -8,7 +8,13 @@ Background:
         | id         | customer_id | address         | status           | 
         | 1          | 1           | 101 king st     | Completed        |         
         | 2          | 2           | 102 king st     | Processing       |       
-        | 3          | 3           | 103 king st     | Processing       |       
+        | 3          | 3           | 103 king st     | Processing       |   
+
+    Given the following items
+        | order_id_index    | item_name       | quantity       | price       | 
+        | 0                 | keyboard        | 1              | 35          |
+        | 0                 | frisbee         | 2              | 10          |
+        | 2                 | kite            | 1              | 20          |    
 
 Scenario: The server is running 
     When I visit the "Home Page"

--- a/features/steps/items_steps.py
+++ b/features/steps/items_steps.py
@@ -1,0 +1,21 @@
+import json
+import requests
+from behave import *
+from compare import expect, ensure 
+
+@given(u'the following items')
+def step_impl(context):
+    """ create new items """
+    headers = {'Content-Type': 'application/json'}
+    for row in context.table:
+        order_id = str(context.order_ids[int(row["order_id_index"])])
+        create_url = context.base_url + "/orders/{}/items".format(order_id)
+        data = {
+            "order_id": order_id,
+            "item_name": row['item_name'],
+            "quantity": row['quantity'],
+            "price": row["price"]
+            }
+        payload = json.dumps(data)
+        context.resp = requests.post(create_url, data=payload, headers=headers)
+        expect(context.resp.status_code).to_equal(201)

--- a/features/steps/orders_steps.py
+++ b/features/steps/orders_steps.py
@@ -32,4 +32,5 @@ def step_impl(context):
             }
         payload = json.dumps(data)
         context.resp = requests.post(create_url, data=payload, headers=headers)
+        context.order_ids.append(context.resp.json()["id"])
         expect(context.resp.status_code).to_equal(201)


### PR DESCRIPTION
Since the database assigns the order_id when creating an order, it becomes problematic to hardcode item samples without knowing the order_id. Here I share a workaround that matches the order_ids created by the database to the hardcoded "order_id_index" attribute in the sample items table. Note: "order_id_index" values mimic the index of a traditional iterable object (i.e., 0, 1, 2, ...).  