### PR TITLE
Fix 500 type error

### DIFF
--- a/features/steps/items_steps.py
+++ b/features/steps/items_steps.py
@@ -9,13 +9,13 @@ def step_impl(context):
     """ create new items """
     headers = {'Content-Type': 'application/json'}
     for row in context.table:
-        order_id = str(context.order_ids[int(row["order_id_index"])])
+        order_id = context.order_ids[int(row["order_id_index"])]
         create_url = context.base_url + "/orders/{}/items".format(order_id)
         data = {
             "order_id": order_id,
             "item_name": row['item_name'],
-            "quantity": row['quantity'],
-            "price": row["price"]
+            "quantity": int(row['quantity']),
+            "price": float(row["price"])
         }
         payload = json.dumps(data)
         context.resp = requests.post(create_url, data=payload, headers=headers)

--- a/service/routes.py
+++ b/service/routes.py
@@ -164,7 +164,7 @@ class OrderResource(Resource):
     @api.doc('update_orders')
     @api.response(404, 'Order not found')
     @api.response(400, 'The posted Order data was not valid')
-    @api.expect(order_model)
+    @api.expect(order_model, validate=True)
     @api.marshal_with(order_model)
     def put(self, order_id):
         """
@@ -362,7 +362,7 @@ class ItemCollection(Resource):
     # ADD A NEW ITEM
     #------------------------------------------------------------------
     @api.doc('create_item')
-    @api.expect(create_item_model)
+    @api.expect(create_item_model, validate=True)
     @api.response(400, 'The posted data was not valid')
     @api.response(201, 'Item created successfully')
     @api.marshal_with(item_model, code=201)

--- a/service/routes.py
+++ b/service/routes.py
@@ -90,7 +90,7 @@ create_item_model = api.model('Item', {
                           description='The order id the item is associated with'),
     'quantity': fields.Integer(required=True,
                               description='The quantity of the item'),
-    'price': fields.Integer(required=True,
+    'price': fields.Float(required=True,
                               description='The price of the item'),
     'item_name': fields.String(required=True,
                                 description='The name of the item')
@@ -128,7 +128,7 @@ order_args.add_argument('item', type=str, location='args', required=False, help=
 ######################################################################
 #  PATH: /orders/{id}
 ######################################################################
-@api.route('/orders/<order_id>')
+@api.route('/orders/<int:order_id>')
 @api.param('order_id', 'The Order identifier')
 class OrderResource(Resource):
 #     """
@@ -261,7 +261,7 @@ class OrderCollection(Resource):
 ######################################################################
 #  PATH: /orders/{id}/cancel
 ######################################################################
-@api.route('/orders/<order_id>/cancel')
+@api.route('/orders/<int:order_id>/cancel')
 @api.param('order_id', 'The Order identifier')
 class CancelResource(Resource):
     """ Cancel actions on a Order """
@@ -295,7 +295,7 @@ class CancelResource(Resource):
 ######################################################################
 #  PATH: /orders/{order_id}/items/{item_id}
 ######################################################################
-@api.route('/orders/<order_id>/items/<item_id>')
+@api.route('/orders/<int:order_id>/items/<int:item_id>')
 @api.param('item_id', 'The Item identifier')
 @api.param('order_id', 'The Order identifier')
 class ItemResource(Resource):
@@ -354,7 +354,7 @@ class ItemResource(Resource):
 ######################################################################
 #  PATH: /orders/{order_id}/items
 ######################################################################
-@api.route('/orders/<order_id>/items', strict_slashes=False)
+@api.route('/orders/<int:order_id>/items', strict_slashes=False)
 @api.param('order_id', 'The Order identifier')
 class ItemCollection(Resource):
     """ Handles all interactions with collections of Items """


### PR DESCRIPTION
* add `validate=True` in every expect to catch type error
   * So that the server can catch type error in a `request body`
   * If anything goes wrong, the server will raise `400 bad request`

* specify path parameters to int
  *  So that the server can catch type error in a `url path`
  * The serve will raise `404 not found : cannot find the route`

* modify step function in `items_step.py` because the data type of request body are specified by `validate=True`

* change data type of `Price` field from int to float